### PR TITLE
Fix broken links, add New Brunswick, update Delaware Lighthouse & USWDS Storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ Click on a table entry below to be taken to more information about it's Design S
 | Underpinning Technology | HTML/CSS/JavaScript | Design components including colors, buttons, forms, tables, grid, typography, navigation tested in live services |
 | Web Components | 🟡 | [USWDS Elements](https://github.com/uswds/uswds-elements) - Web Component-based version available |
 | 508 Compliant | 🟢 | Meets WCAG 2.0 AA and Section 508 standards. Tries to meet WCAG 2.1 requirements. Accessibility issues prioritized. One of five core design principles is "Embrace accessibility" |
-| Storybook / Figma | 🔴 | Comprehensive documentation at designsystem.digital.gov |
+| Storybook / Figma | 🟢 | [USWDS Storybook](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/) (develop preview) available; comprehensive documentation at designsystem.digital.gov |
 
 ### [Uruguay](https://www.gub.uy/uruguay-digital/en)
 | **Feature** | **Status** | **Other Info** |
@@ -952,14 +952,14 @@ Click on a table entry below to be taken to more information about it's Design S
 | 508 Compliant | 🟢 | **WCAG 2.1 Level AA standards required**. Universal Website Accessibility Policy enforces Level AA compliance as primary guideline for all state websites |
 | Storybook / Figma | 🔴 | IT Strategic Plan 2025 for digital government services. Design system guidelines for headings, lists, and consistent structure |
 
-### [United States - Delaware](https://gic.delaware.gov/)
+### [United States - Delaware](https://lighthouse.delaware.gov/)
 | **Feature** | **Status** | **Other Info** |
 | :---------- | :--------- | :------------- |
-| No Public Source Code Found | **Lighthouse Design System - Launched January 2025** | Lighthouse is Delaware's state government website design system offering accessibility compliance, research-driven UI improvements, and easier editing process for state agency WordPress websites. Government Information Center (GIC) creates websites and digital branding assets specifically tailored for State of Delaware entities |
-| Underpinning Technology | WordPress-based | New branding debuted with first Lighthouse website January 2025. As agencies adopt Lighthouse for websites, they acquire new standardized branding. GIC delivers clear, accessible solutions making online services easy and seamless for First State citizens |
-| Web Components | 🟢 | Lighthouse design system provides standardized components for WordPress. Go DE platform features 100+ digital services with integrated payment processing (Pay with Go DE) and resident portal secured by myDelaware identity system |
-| 508 Compliant | 🟢 | Accessibility compliance built into Lighthouse design system. State aims to make 80% of government services available online with all websites inclusive and accessible. GEAR report 2025 outlines scaling digital government services |
-| Storybook / Figma | 🔴 | GIC provides comprehensive website and digital branding services. Go DE portal preparing to deploy chatbots and AI tools, with digital signature workflows and document upload capabilities |
+| Source Code Freely Available (via [Storybook](https://lighthouse.delaware.gov/)) | **Lighthouse Design System - Launched January 2025** | Lighthouse is Delaware's state government website design system - a collection of reusable, accessibility-tested web components and templates (accordions, buttons, lists, form inputs, curated color palettes) with research-driven design and content guidance. Source code is freely available for anyone to use. Maintained by the Government Information Center (GIC) |
+| Underpinning Technology | WordPress + HTML/CSS/JS | Integrates within WordPress and supports third-party implementations through available code files and documentation. New standardized branding debuted with the first Lighthouse website in January 2025 |
+| Web Components | 🟢 | Reusable, accessibility-tested components and templates for consistent layouts across platforms. Go DE platform features 100+ digital services with integrated payment processing (Pay with Go DE) and resident portal secured by myDelaware identity system |
+| 508 Compliant | 🟢 | All Lighthouse elements and components meet or exceed WCAG 2.1 AA. Color palettes selected to avoid contrast and other visual accessibility issues |
+| Storybook / Figma | 🟢 | Full Lighthouse documentation available on the [Storybook page](https://lighthouse.delaware.gov/), with HTML shared through Storybook |
 
 ### [United States - Georgia](https://dhs.georgia.gov/organization/about-gta/orchard)
 | **Feature** | **Status** | **Other Info** |


### PR DESCRIPTION
## Summary

Follow-up improvements on top of the merged #5, covering a full link audit, one new design system, and two entry updates (one from a user request, one resolving #8).

## Link audit & fixes

Audited every outbound link in `README.md` and corrected the broken/stale ones:

- **NASA** — `nasa/nasawds-site` source repo was **archived (Feb 2020)**; updated to the active community-maintained [`bruffridge/nasawds`](https://github.com/bruffridge/nasawds) (v4.0.70, June 2025)
- **UK Ministry of Defence** — source repo was renamed; updated `defencedigital/mod-uk-design-system` → [`defencedigital/moduk-frontend`](https://github.com/defencedigital/moduk-frontend)
- **Massachusetts** — fixed heading URL from `http://` to `https://`
- **Australia – NSW** — Figma link incorrectly pointed at the B.C. Design System file; corrected to the NSW Design System Figma docs
- **Ukraine** — replaced the inaccessible `diia.fedoriv.com` heading URL with the official [open-source portal](https://opensource.diia.gov.ua/en.html)

## New entry

- 🇨🇦 **Canada – New Brunswick** — [GNB Design System](https://design-system.transformationnb.ca/en/) (State / Regional). HTML/CSS/JS Code Kit with reusable components and a design kit, bilingual EN/FR, 8px grid, mobile-first 12-column flexbox, targeting WCAG 2.2 AA. Placed alphabetically between British Columbia and Ontario in both the nav table and detail section.

## Entry updates

- 🇺🇸 **Delaware** — pointed the entry at the [Lighthouse Design System](https://lighthouse.delaware.gov/), noted the freely available source code, and flipped Storybook to available with the Lighthouse Storybook link
- 🇺🇸 **USWDS** — added the [USWDS Storybook](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/) (develop preview) link — **resolves #8**

## Validation

All in-page anchor links were re-validated after each change (**132 anchors, 0 missing**), and the nav table's State/Regional column was cross-checked against the detail entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzNBgibbM8onnvKa72FnEC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzNBgibbM8onnvKa72FnEC)_